### PR TITLE
Add basic instructions for installing on Linux

### DIFF
--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -1,0 +1,17 @@
+## Installing R5Valkyrie on linux
+
+### Debian/Ubuntu 
+
+1. Download the latest release of the launcher from https://github.com/r5valkyrie/launcher/releases/latest
+* Make sure that you download the release marked as being for Debian.
+2. Open a terminal window and navigate to your downloads folder with
+```
+  cd Downloads
+```
+3. After that install the file with
+```
+sudo dpkg -i R5Valkyrie.Launcher-x.x.xx-Debian.deb
+```
+* Make sure to replace the x.x.xx with the propper version number from your download. Or type out R5 and hit the tab key to autofill the full file name.
+4. ???
+5. Profit

--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -26,7 +26,8 @@ Either install the [Latest release](https://github.com/r5valkyrie/launcher/relea
 yay -S r5valkyrie-launcher-bin
 ```
 2. Follow the on screen instructions to further install the AUR package.
-
+3. ???
+4. Profit
 
 #### Installing it manually:
 

--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -15,3 +15,26 @@ sudo dpkg -i R5Valkyrie.Launcher-x.x.xx-Debian.deb
 * Make sure to replace the x.x.xx with the propper version number from your download. Or type out R5 and hit the tab key to autofill the full file name.
 4. ???
 5. Profit
+
+### Arch Linux
+
+Either install the [Latest release](https://github.com/r5valkyrie/launcher/releases/latest) or use [the AUR](https://aur.archlinux.org/packages/r5valkyrie-launcher-bin)
+
+#### Using the AUR (recommended):
+1. Use your favorite AUR helper to install the package like this
+```
+yay -S r5valkyrie-launcher-bin
+```
+2. Follow the on screen instructions to further install the AUR package.
+
+
+#### Installing it manually:
+
+1. Download the [latest release](https://github.com/r5valkyrie/launcher/releases/latest)
+2. Install the package with
+```
+    pacman -U R5Valkyrie.Launcher-x.x.xx-Debian.deb
+```
+3. ???
+4. Profit
+

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -11,6 +11,10 @@
                 {
                     "title": "Getting Started",
                     "slug": "getting-started"
+                },
+                {
+                    "title": "Installing R5Valkyrie on Linux",
+                    "slug": "install-linux"
                 }
             ]
         },


### PR DESCRIPTION
This adds basic instructions on how to install R5Valkyrie on Linux. I've only covered Debian and Arch for now since that's what I'm the most familiar with myself. I kept the Arch instructions as light as possible but they might need to be expanded to cover what an "aur helper" is (since the steamdeck runs on arch Linux). Lmk if there's any changes that are needed